### PR TITLE
Customize error response

### DIFF
--- a/app/composer.json
+++ b/app/composer.json
@@ -17,6 +17,7 @@
         "symfony/framework-bundle": "6.2.*",
         "symfony/runtime": "6.2.*",
         "symfony/security-bundle": "6.2.*",
+        "symfony/validator": "6.2.*",
         "symfony/yaml": "6.2.*"
     },
     "require-dev": {

--- a/app/composer.lock
+++ b/app/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4815a397be342430b2fef917fef39bb6",
+    "content-hash": "9cb7f2dcf9ca5ef1beb0737f4fdfc9d3",
     "packages": [
         {
             "name": "doctrine/cache",
@@ -4728,6 +4728,114 @@
                 }
             ],
             "time": "2023-03-01T10:32:47+00:00"
+        },
+        {
+            "name": "symfony/validator",
+            "version": "v6.2.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/validator.git",
+                "reference": "c63584f84edbdba9d2519f888350dd90615abe35"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/validator/zipball/c63584f84edbdba9d2519f888350dd90615abe35",
+                "reference": "c63584f84edbdba9d2519f888350dd90615abe35",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "symfony/deprecation-contracts": "^2.1|^3",
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/translation-contracts": "^1.1|^2|^3"
+            },
+            "conflict": {
+                "doctrine/annotations": "<1.13",
+                "doctrine/lexer": "<1.1",
+                "phpunit/phpunit": "<5.4.3",
+                "symfony/dependency-injection": "<5.4",
+                "symfony/expression-language": "<5.4",
+                "symfony/http-kernel": "<5.4",
+                "symfony/intl": "<5.4",
+                "symfony/property-info": "<5.4",
+                "symfony/translation": "<5.4",
+                "symfony/yaml": "<5.4"
+            },
+            "require-dev": {
+                "doctrine/annotations": "^1.13|^2",
+                "egulias/email-validator": "^2.1.10|^3|^4",
+                "symfony/cache": "^5.4|^6.0",
+                "symfony/config": "^5.4|^6.0",
+                "symfony/console": "^5.4|^6.0",
+                "symfony/dependency-injection": "^5.4|^6.0",
+                "symfony/expression-language": "^5.4|^6.0",
+                "symfony/finder": "^5.4|^6.0",
+                "symfony/http-client": "^5.4|^6.0",
+                "symfony/http-foundation": "^5.4|^6.0",
+                "symfony/http-kernel": "^5.4|^6.0",
+                "symfony/intl": "^5.4|^6.0",
+                "symfony/mime": "^5.4|^6.0",
+                "symfony/property-access": "^5.4|^6.0",
+                "symfony/property-info": "^5.4|^6.0",
+                "symfony/translation": "^5.4|^6.0",
+                "symfony/yaml": "^5.4|^6.0"
+            },
+            "suggest": {
+                "egulias/email-validator": "Strict (RFC compliant) email validation",
+                "psr/cache-implementation": "For using the mapping cache.",
+                "symfony/config": "",
+                "symfony/expression-language": "For using the Expression validator and the ExpressionLanguageSyntax constraints",
+                "symfony/http-foundation": "",
+                "symfony/intl": "",
+                "symfony/property-access": "For accessing properties within comparison constraints",
+                "symfony/property-info": "To automatically add NotNull and Type constraints",
+                "symfony/translation": "For translating validation errors.",
+                "symfony/yaml": ""
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Validator\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides tools to validate values",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/validator/tree/v6.2.8"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-03-20T16:06:02+00:00"
         },
         {
             "name": "symfony/var-dumper",

--- a/app/config/packages/framework.yaml
+++ b/app/config/packages/framework.yaml
@@ -18,6 +18,8 @@ framework:
     php_errors:
         log: true
 
+    error_controller: App\Controller\ErrorController::show
+
 when@test:
     framework:
         test: true

--- a/app/config/packages/validator.yaml
+++ b/app/config/packages/validator.yaml
@@ -1,0 +1,13 @@
+framework:
+    validation:
+        email_validation_mode: html5
+
+        # Enables validator auto-mapping support.
+        # For instance, basic validation constraints will be inferred from Doctrine's metadata.
+        #auto_mapping:
+        #    App\Entity\: []
+
+when@test:
+    framework:
+        validation:
+            not_compromised_password: false

--- a/app/src/Controller/API/RegistrationController.php
+++ b/app/src/Controller/API/RegistrationController.php
@@ -4,20 +4,24 @@ namespace App\Controller\API;
 
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Lexik\Bundle\JWTAuthenticationBundle\Services\JWTTokenManagerInterface;
 use App\Entity\User;
+use App\Controller\BaseController;
 
-
-class RegistrationController extends AbstractController
+class RegistrationController extends BaseController
 {
     #[Route('/register', methods: ['POST'])]
     public function register(EntityManagerInterface $entityManager, UserPasswordHasherInterface $passwordHasher, Request $request, JWTTokenManagerInterface $JWTManager): JsonResponse
     {
         $parameters = json_decode($request->getContent(), true);
+
+        if ($entityManager->getRepository(User::class)->findOneBy(["login" => $parameters['login']]) != null)
+            return $this->error("Login already taken", Response::HTTP_BAD_REQUEST);
 
         $user = new User();
         $user->setLogin($parameters['login']);

--- a/app/src/Controller/BaseController.php
+++ b/app/src/Controller/BaseController.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+
+class BaseController extends AbstractController
+{
+    protected function error(string $error, int $status_code, array $headers = [], array $context = []): JsonResponse
+    {
+        return $this->json([
+            'error' => $error,
+        ], $status_code, $headers, $context);
+    }
+}

--- a/app/src/Controller/ErrorController.php
+++ b/app/src/Controller/ErrorController.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\ErrorHandler\Exception\FlattenException;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpKernel\KernelInterface;
+use Symfony\Component\HttpKernel\Log\DebugLoggerInterface;
+
+class ErrorController extends AbstractController
+{
+    public function show(FlattenException $exception, DebugLoggerInterface $logger = null, KernelInterface $kernel): JsonResponse
+    {
+        $res = ["error" => $exception->getStatusText()];
+        if ($kernel->getEnvironment() == "dev")
+            $res["details"] = $exception->getMessage();
+
+        return $this->json($res, $exception->getStatusCode());
+    }
+}

--- a/app/src/Request/BaseRequest.php
+++ b/app/src/Request/BaseRequest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Request;
+
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\KernelInterface;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+abstract class BaseRequest
+{
+    public function __construct(protected ValidatorInterface $validator, protected KernelInterface $kernel)
+    {
+        $this->populate();
+
+        if ($this->autoValidateRequest()) {
+            $this->validate();
+        }
+    }
+
+    public function validate()
+    {
+        $errors = $this->validator->validate($this);
+        if (count($errors) == 0)
+            return;
+
+        $res = ['error' => 'Parameters validation failed'];
+
+        if ($this->kernel->getEnvironment() == "dev") {
+            $res['errors'] = [];
+            /** @var \Symfony\Component\Validator\ConstraintViolation  */
+            foreach ($errors as $message) {
+                $res['errors'][] = [
+                    'property' => $message->getPropertyPath(),
+                    'value' => $message->getInvalidValue(),
+                    'message' => $message->getMessage(),
+                ];
+            }
+
+        }
+
+        $response = new JsonResponse($res, Response::HTTP_UNPROCESSABLE_ENTITY);
+        $response->send();
+    }
+
+    public function getRequest(): Request
+    {
+        return Request::createFromGlobals();
+    }
+
+    protected function populate(): void
+    {
+        foreach ($this->getRequest()->toArray() as $property => $value) {
+            if (property_exists($this, $property)) {
+                $this->{$property} = $value;
+            }
+        }
+    }
+
+    protected function autoValidateRequest(): bool
+    {
+        return true;
+    }
+}

--- a/app/src/Request/RegistrationRequest.php
+++ b/app/src/Request/RegistrationRequest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Request;
+
+use Symfony\Component\Validator\Constraints\Length;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Constraints\Type;
+use Symfony\Component\Validator\Constraints\Email;
+
+class RegistrationRequest extends BaseRequest
+{
+    #[Type('string')]
+    #[NotBlank()]
+    #[Length(max: 180)]
+    public $login;
+
+    #[Type('string')]
+    #[NotBlank()]
+    #[Email()]
+    #[Length(max: 255)]
+    public $email;
+
+    #[Type('string')]
+    #[NotBlank()]
+    #[Length(max: 255)]
+    public $password;
+
+    #[Type('string')]
+    #[NotBlank()]
+    #[Length(max: 255)]
+    public $firstname;
+
+    #[Type('string')]
+    #[NotBlank()]
+    #[Length(max: 255)]
+    public $lastname;
+}

--- a/app/symfony.lock
+++ b/app/symfony.lock
@@ -123,5 +123,17 @@
         "files": [
             "config/packages/security.yaml"
         ]
+    },
+    "symfony/validator": {
+        "version": "6.2",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "main",
+            "version": "5.3",
+            "ref": "c32cfd98f714894c4f128bb99aa2530c1227603c"
+        },
+        "files": [
+            "config/packages/validator.yaml"
+        ]
     }
 }


### PR DESCRIPTION
## Unhandled exceptions

In case of an unhandled exceptions, the ErrorController is used and returns a json error witht he following fields:

- error : Status code meaning (400 -> Bad request, 500 -> Internal Server Error...)
- details: Exception message, only in dev mode

Example for an error 500:
```json
{
    "error": "Internal Server Error",
    "details": "An exception occurred while executing a query: SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry 'toto@gmail.com' for key 'UNIQ_8D93D649E7927C74'"
}
```

## Handled errors

A new **BaseController** class has been introduced with a protected **error()** method.
All controllers must inherit this class and use the error method when an error occurs.

The error method take at least two parameters:
- $error: the error message
- $status_code: the response code

Example:

```php
 if ($entityManager->getRepository(User::class)->findOneBy(["login" => $parameters['login']]) != null)
            return $this->error("Login already taken", Response::HTTP_BAD_REQUEST);
```

Will return an error response with a status code a 400 (Bad Request) if the condition is valid:

```json
{
    "error": "Login already taken"
}
```

## Request Validators

A new **BaseRequest** class has been introduced to handle request parameters validation

See RegistrationRequest for an example and https://symfony.com/doc/current/validation.html#constraints for available constraints.



Close #15