### PR TITLE
Fix JWT error messages format

### DIFF
--- a/app/config/packages/security.yaml
+++ b/app/config/packages/security.yaml
@@ -22,11 +22,12 @@ security:
                 username_path: login
                 check_path: /api/login
                 success_handler: lexik_jwt_authentication.handler.authentication_success
-                failure_handler: lexik_jwt_authentication.handler.authentication_failure
+                failure_handler: App\Security\Authentication\AuthenticationFailureHandler
 
         api:
             stateless: true
-            jwt: ~
+            jwt: 
+                authenticator: app.jwt_token_authenticator
 
 
     # Easy way to control access for large sections of your site

--- a/app/config/services.yaml
+++ b/app/config/services.yaml
@@ -22,3 +22,7 @@ services:
 
     # add more service definitions when explicit configuration is needed
     # please note that last definitions always *replace* previous ones
+    
+    app.jwt_token_authenticator:
+        class: App\Security\Authentication\Authenticator
+        parent: lexik_jwt_authentication.security.jwt_authenticator

--- a/app/src/Security/Authentication/AuthenticationFailureHandler.php
+++ b/app/src/Security/Authentication/AuthenticationFailureHandler.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Security\Authentication;
+
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerInterface;
+use Symfony\Component\HttpFoundation\Response;
+
+class AuthenticationFailureHandler implements AuthenticationFailureHandlerInterface
+{
+    public function onAuthenticationFailure(Request $request, \Symfony\Component\Security\Core\Exception\AuthenticationException $exception): JsonResponse
+    {
+        return new JsonResponse(['error' => "Invalid credentials"], Response::HTTP_UNAUTHORIZED);
+    }
+}

--- a/app/src/Security/Authentication/Authenticator.php
+++ b/app/src/Security/Authentication/Authenticator.php
@@ -1,0 +1,33 @@
+<?php
+
+
+namespace App\Security\Authentication;
+
+use Symfony\Component\HttpFoundation\Request;
+use Lexik\Bundle\JWTAuthenticationBundle\Exception\ExpiredTokenException;
+use Symfony\Component\HttpFoundation\Response;
+use Lexik\Bundle\JWTAuthenticationBundle\Security\Authenticator\JWTAuthenticator;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+
+class Authenticator extends JWTAuthenticator
+{
+    ## Authentication is require (no token provided)
+    public function start(Request $request, AuthenticationException $authException = null): Response
+    {
+        $response = parent::start($request, $authException);
+        $response->setContent(json_encode(['error' => "Bearer token not found"]));
+        return $response;
+    }
+
+    ## Bearer token is invalid (maybe expired)
+    public function onAuthenticationFailure(Request $request, AuthenticationException $exception): ?Response
+    {
+        $response = parent::onAuthenticationFailure($request, $exception);
+        if ($exception instanceof ExpiredTokenException) {
+            $response->setContent(json_encode(["error" => "Bearer token expired"]));
+        } else {
+            $response->setContent(json_encode(["error" => "Bearer token is invalid"]));
+        }
+        return $response;
+    }
+}


### PR DESCRIPTION
JWT (Bearer tokens) now have the same error format as the other errors:

Ex:
```json
{
  "error": "Invalid credentials"
}
```

Close #20